### PR TITLE
Made metallic hydrogen golems not horrible

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -1238,7 +1238,6 @@
 	prefix = "Metallic Hydrogen"
 	stunmod = 0.6 //as opposed to plasteel's 0.4
 	special_names = list("Primordial","Atomic","Indivisible","Protonic")
-	primodrial atomic indivisible protonic
 	armor = 75 //5 more than diamond, 20 more than base golem. balance as necessary, this just seems right
 	inherent_traits = list(TRAIT_VIRUSIMMUNE,TRAIT_RESISTHEAT,TRAIT_NOBREATH,TRAIT_RESISTCOLD,TRAIT_RESISTHIGHPRESSURE,TRAIT_RESISTLOWPRESSURE,TRAIT_NOFIRE,TRAIT_RADIMMUNE,TRAIT_GENELESS,TRAIT_PIERCEIMMUNE,TRAIT_NODISMEMBER,TRAIT_NOHUNGER,TRAIT_NOGUNS) //added virusimmune because they're too tough for disease
 

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -1237,7 +1237,8 @@
 	info_text = "As a <span class='danger'>Metallic Hydrogen Golem</span>, you were forged in the highest pressures and the highest heats. Your unique mineral makeup makes you tougher than diamond."
 	prefix = "Metallic Hydrogen"
 	stunmod = 0.6 //as opposed to plasteel's 0.4
-	special_names = ("Primordial","Atomic","Indivisible","Protonic")
+	special_names = list("Primordial","Atomic","Indivisible","Protonic")
+	primodrial atomic indivisible protonic
 	armor = 75 //5 more than diamond, 20 more than base golem. balance as necessary, this just seems right
 	inherent_traits = list(TRAIT_VIRUSIMMUNE,TRAIT_RESISTHEAT,TRAIT_NOBREATH,TRAIT_RESISTCOLD,TRAIT_RESISTHIGHPRESSURE,TRAIT_RESISTLOWPRESSURE,TRAIT_NOFIRE,TRAIT_RADIMMUNE,TRAIT_GENELESS,TRAIT_PIERCEIMMUNE,TRAIT_NODISMEMBER,TRAIT_NOHUNGER,TRAIT_NOGUNS) //added virusimmune because they're too tough for disease
 

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -1234,10 +1234,12 @@
 	name = "Metallic Hydrogen Golem"
 	id = "Metallic Hydrogen golem"
 	fixed_mut_color = "ddd"
-	info_text = "As a <span class='danger'>Metallic Hydrogen Golem</span>, you were forged in the highest pressures and the highest heats. Your unique mineral makeup makes you immune to most types of damages."
+	info_text = "As a <span class='danger'>Metallic Hydrogen Golem</span>, you were forged in the highest pressures and the highest heats. Your unique mineral makeup makes you tougher than diamond."
 	prefix = "Metallic Hydrogen"
-	special_names = null
-	inherent_traits = list(TRAIT_RESISTHEAT,TRAIT_NOBREATH,TRAIT_RESISTHIGHPRESSURE,TRAIT_NOFIRE,TRAIT_RADIMMUNE,TRAIT_GENELESS,TRAIT_NODISMEMBER)
+	stunmod = 0.6 //as opposed to plasteel's 0.4
+	special_names = ("Primordial","Atomic","Indivisible","Protonic")
+	armor = 75 //5 more than diamond, 20 more than base golem. balance as necessary, this just seems right
+	inherent_traits = list(TRAIT_VIRUSIMMUNE,TRAIT_RESISTHEAT,TRAIT_NOBREATH,TRAIT_RESISTCOLD,TRAIT_RESISTHIGHPRESSURE,TRAIT_RESISTLOWPRESSURE,TRAIT_NOFIRE,TRAIT_RADIMMUNE,TRAIT_GENELESS,TRAIT_PIERCEIMMUNE,TRAIT_NODISMEMBER,TRAIT_NOHUNGER,TRAIT_NOGUNS) //added virusimmune because they're too tough for disease
 
 /datum/species/golem/mhydrogen/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	. = ..()


### PR DESCRIPTION
### Intent of your Pull Request

Thanks to TG, they used to not even be spaceproof, lol
Now they have slightly better armor than diamond, slightly worse stunmod than plasteel, virus immunity (uniquely), and their other inherent_traits are not worse than iron golems
Also I added some special_names whatever that means
Not tested, should be too simple to screw up though.

### Why is this good for the game?

Because as it is, metallic hydrogen golems are... worse than iron golems with antimagic, which is really sad for about the hardest non-antag golem to make

#### Changelog

:cl:  
tweak: made mhydrogen golems actually spaceproof and gave them superb armor
/:cl:

another idea to make them interesting is to remove NOFIRE, which i think? makes them able to carry fire without making them burnable by it, its in theme with atmos and also hydrogen is flammable