### PR TITLE
Maybe removes bombanas from gold slime pool

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1486,7 +1486,8 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 		/obj/item/reagent_containers/food/snacks/store/bread,
 		/obj/item/reagent_containers/food/snacks/grown/nettle
 		)
-	blocked |= typesof(/obj/item/reagent_containers/food/snacks/customizable)
+	blocked |= typesof(/obj/item/reagent_containers/food/snacks/customizable,
+	/obj/item/reagent_containers/food/snacks/grown/banana/bombanana)
 
 	return pick(subtypesof(/obj/item/reagent_containers/food/snacks) - blocked)
 


### PR DESCRIPTION
# Document the changes in your pull request
On one hand xenobiologists deserve it, on the other, what

# Changelog

:cl:  
rscdel: Central Command has issued an ordinance banning slime extracts from spawning explosives concealed under the guise of food.
/:cl: